### PR TITLE
Add EMA smoothing to anomaly scores

### DIFF
--- a/networks/base_model.py
+++ b/networks/base_model.py
@@ -162,3 +162,12 @@ class BaseModel(object):
         eval_data_anomaly_score_csv_path = self.eval_data_result_dir / os.path.basename(anomaly_score_csv_path).replace(self.model_name_suffix, "")
         print(f"copy anomaly score: {anomaly_score_csv_path}\n\t->{eval_data_anomaly_score_csv_path}")
         shutil.copyfile(anomaly_score_csv_path, eval_data_anomaly_score_csv_path)
+
+    def apply_ema(self, values, alpha=0.2):
+        """Apply Exponential Moving Average smoothing to a list of values."""
+        smoothed = []
+        ema = None
+        for v in values:
+            ema = v if ema is None else alpha * v + (1 - alpha) * ema
+            smoothed.append(ema)
+        return smoothed

--- a/networks/dcase2023t2_ae/dcase2023t2_ae.py
+++ b/networks/dcase2023t2_ae/dcase2023t2_ae.py
@@ -339,6 +339,12 @@ class DCASE2023T2AE(BaseModel):
                     inv_cov_target=inv_cov_target,
                 )
 
+            # apply EMA smoothing to anomaly scores
+            smoothed_scores = self.apply_ema([s[1] for s in anomaly_score_list])
+            for idx, score in enumerate(smoothed_scores):
+                anomaly_score_list[idx][1] = score
+            y_pred = smoothed_scores
+
             # output anomaly scores
             save_csv(save_file_path=anomaly_score_csv, save_data=anomaly_score_list)
             print("anomaly score result ->  {}".format(anomaly_score_csv))


### PR DESCRIPTION
## Summary
- implement `apply_ema` helper in `BaseModel`
- smooth predicted anomaly scores in `DCASE2023T2AE.test`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe93550688331a69a0379f1b106e3