### PR TITLE
Add BEATs-based feature extraction and memory bank pipeline

### DIFF
--- a/beats_feature_extractor.py
+++ b/beats_feature_extractor.py
@@ -1,0 +1,115 @@
+"""Feature extraction using the BEATs pre-trained model.
+
+This module provides a thin wrapper around the BEATs model from the
+``transformers`` library.  It extracts embeddings from an input waveform and
+applies mean-pooling over the temporal dimension while keeping the spectral
+structure.  The resulting feature vector has shape ``[F * C]`` where ``F`` is
+the number of spectral patches and ``C`` is the hidden size of the model.
+
+The implementation follows the pipeline described in the project
+requirements:
+
+1. Run a forward pass of the BEATs model to obtain patch embeddings with
+   shape ``[B, T*F, C]``.
+2. Reshape the sequence dimension into ``[T, F]`` to recover the temporal and
+   spectral dimensions.
+3. Apply mean pooling over the temporal dimension only, obtaining
+   ``[B, F, C]``.
+4. Flatten the pooled embedding into ``[B, F*C]`` which can be stored in a
+   memory bank.
+
+The code relies on ``transformers`` and ``torch``.  Importing this module will
+not instantiate the model until :class:`BEATsFeatureExtractor` is constructed,
+so environments without these dependencies can still import the file without
+immediate failures.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency
+    import torch
+    from transformers import BEATsModel, BEATsProcessor
+except Exception as err:  # pragma: no cover - handle missing deps gracefully
+    torch = None  # type: ignore
+    BEATsModel = None  # type: ignore
+    BEATsProcessor = None  # type: ignore
+    _IMPORT_ERROR = err
+else:  # pragma: no cover - no error
+    _IMPORT_ERROR = None
+
+
+@dataclass
+class BEATsFeatureExtractor:  # pragma: no cover - small wrapper
+    """Extract features from waveforms using a pre-trained BEATs model.
+
+    Parameters
+    ----------
+    model_name:
+        Name of the pre-trained BEATs checkpoint hosted on Hugging Face.
+    device:
+        Torch device on which the model will run.  If ``None`` the device is
+        chosen automatically.
+    """
+
+    model_name: str = "microsoft/beats-base"
+    device: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if BEATsModel is None or BEATsProcessor is None:
+            raise ImportError(
+                "BEATsFeatureExtractor requires `torch` and `transformers` to be installed."
+            ) from _IMPORT_ERROR
+
+        self.device = self.device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.processor = BEATsProcessor.from_pretrained(self.model_name)
+        self.model = BEATsModel.from_pretrained(self.model_name).to(self.device)
+        self.model.eval()
+
+        config = self.model.config
+        # Estimate the number of spectral patches produced by the model.  This
+        # depends on the number of mel bins and the frequency patch size.
+        num_mels = getattr(config, "num_mel_bins", 128)
+        patch_size = getattr(config, "patch_size", 16)
+        if isinstance(patch_size, (list, tuple)):
+            patch_freq = patch_size[-1]
+        else:
+            patch_freq = patch_size
+        self.freq_patches = max(1, num_mels // patch_freq)
+
+    @torch.no_grad()
+    def __call__(self, waveform: "torch.Tensor", sample_rate: int) -> "torch.Tensor":
+        """Extract pooled BEATs embeddings from an input waveform.
+
+        Parameters
+        ----------
+        waveform:
+            A tensor containing the audio waveform with shape ``[n_samples]`` or
+            ``[channel, n_samples]``.  The audio is assumed to be mono or the
+            first channel is used.
+        sample_rate:
+            Sampling rate of the waveform.
+
+        Returns
+        -------
+        torch.Tensor
+            A tensor of shape ``[F * C]`` containing the pooled embedding.
+        """
+
+        if waveform.dim() == 1:
+            waveform = waveform.unsqueeze(0)
+
+        inputs = self.processor(
+            waveform, sampling_rate=sample_rate, return_tensors="pt"
+        )
+        inputs = {k: v.to(self.device) for k, v in inputs.items()}
+        outputs = self.model(**inputs)
+
+        embeddings = outputs.last_hidden_state  # [B, T*F, C]
+        bsz, seq_len, hidden = embeddings.shape
+        freq = self.freq_patches
+        time = seq_len // freq
+        embeddings = embeddings.view(bsz, time, freq, hidden)  # [B, T, F, C]
+        pooled = embeddings.mean(dim=1)  # [B, F, C]
+        return pooled.reshape(bsz, freq * hidden)

--- a/beats_knn_pipeline.py
+++ b/beats_knn_pipeline.py
@@ -1,0 +1,90 @@
+"""High-level pipeline tying BEATs feature extraction with memory-based kNN.
+
+The module exposes convenience functions to build source/target memory banks
+and to compute anomaly scores for new samples.  It does not depend on any
+specific dataset structure; callers are expected to provide raw waveforms.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import torch
+except Exception as err:  # pragma: no cover
+    torch = None  # type: ignore
+    _IMPORT_ERROR = err
+else:  # pragma: no cover
+    _IMPORT_ERROR = None
+
+from beats_feature_extractor import BEATsFeatureExtractor
+from memory_utils import memory_mixup, knn_anomaly_score
+
+
+def _check_torch() -> None:  # pragma: no cover - helper
+    if torch is None:
+        raise ImportError("BEATs pipeline requires `torch` to be installed") from _IMPORT_ERROR
+
+
+def build_memory_banks(
+    source_waveforms: Iterable["torch.Tensor"],
+    target_waveforms: Iterable["torch.Tensor"],
+    sample_rate: int,
+    *,
+    extractor: BEATsFeatureExtractor | None = None,
+    k_mixup: int = 5,
+) -> Tuple["torch.Tensor", "torch.Tensor"]:
+    """Create source and (augmented) target memory banks.
+
+    Parameters
+    ----------
+    source_waveforms, target_waveforms:
+        Iterables of waveform tensors.
+    sample_rate:
+        Sampling rate shared by all waveforms.
+    extractor:
+        Optional :class:`BEATsFeatureExtractor` instance.  A new extractor is
+        created if not provided.
+    k_mixup:
+        Number of neighbours used when augmenting the target memory bank via
+        memory mixup.
+    """
+    _check_torch()
+    extractor = extractor or BEATsFeatureExtractor()
+
+    src_feats = [extractor(w, sample_rate) for w in source_waveforms]
+    tgt_feats = [extractor(w, sample_rate) for w in target_waveforms]
+    src_bank = torch.vstack(src_feats)
+    tgt_bank = torch.vstack(tgt_feats)
+    tgt_bank = memory_mixup(tgt_bank, src_bank, k=k_mixup)
+    return src_bank, tgt_bank
+
+
+def score_sample(
+    waveform: "torch.Tensor",
+    sample_rate: int,
+    source_bank: "torch.Tensor",
+    target_bank: "torch.Tensor",
+    *,
+    extractor: BEATsFeatureExtractor | None = None,
+    k: int = 5,
+) -> Tuple[float, float, float]:
+    """Compute the anomaly score for ``waveform``.
+
+    Parameters
+    ----------
+    waveform:
+        Waveform tensor representing the test sample.
+    sample_rate:
+        Sampling rate of the waveform.
+    source_bank, target_bank:
+        Memory banks built with :func:`build_memory_banks`.
+    extractor:
+        Optional feature extractor instance.
+    k:
+        Number of neighbours used for kNN scoring.
+    """
+    _check_torch()
+    extractor = extractor or BEATsFeatureExtractor()
+    feat = extractor(waveform, sample_rate)
+    # ``feat`` has shape [1, D]; squeeze to 1-D before scoring.
+    return knn_anomaly_score(feat.squeeze(0), source_bank, target_bank, k=k)

--- a/memory_utils.py
+++ b/memory_utils.py
@@ -1,0 +1,122 @@
+"""Utility functions for feature memory banks used in anomaly detection.
+
+This module implements two core components of the BEATs-based pipeline:
+
+1. **Memory Mixup** – Augments target-domain features when the amount of
+   available target data is limited.  Each target feature is interpolated with
+   its nearest ``K`` source-domain features, creating synthetic examples that
+   mitigate domain shift.
+2. **kNN Anomaly Scoring** – Computes the k-nearest-neighbour distance of a
+   test sample against both source and target memory banks.  The minimum of the
+   two distances serves as the final anomaly score, while the individual
+   distances are also returned for inspection.
+
+The functions operate on ``torch.Tensor`` inputs but are written to be
+self-contained and easily testable.
+"""
+from __future__ import annotations
+
+from typing import Tuple
+
+try:  # pragma: no cover - optional dependency
+    import torch
+except Exception as err:  # pragma: no cover
+    torch = None  # type: ignore
+    _IMPORT_ERROR = err
+else:  # pragma: no cover
+    _IMPORT_ERROR = None
+
+
+def _check_torch() -> None:  # pragma: no cover - helper
+    if torch is None:
+        raise ImportError(
+            "memory_utils requires `torch` to be installed"
+        ) from _IMPORT_ERROR
+
+
+def memory_mixup(
+    target_feats: "torch.Tensor", source_feats: "torch.Tensor", k: int = 5, seed: int | None = None
+) -> "torch.Tensor":
+    """Augment target-domain features by interpolating with source features.
+
+    Parameters
+    ----------
+    target_feats:
+        Tensor of shape ``[N_t, D]`` representing target-domain features.
+    source_feats:
+        Tensor of shape ``[N_s, D]`` representing source-domain features.
+    k:
+        Number of nearest neighbours from the source domain to mix with each
+        target feature.
+    seed:
+        Optional random seed to make the augmentation deterministic.
+
+    Returns
+    -------
+    torch.Tensor
+        Augmented target features containing the original target features and
+        the synthetic ones generated via interpolation.
+    """
+    _check_torch()
+
+    if target_feats.ndim != 2 or source_feats.ndim != 2:
+        raise ValueError("Input feature matrices must be 2-D")
+    if target_feats.size(1) != source_feats.size(1):
+        raise ValueError("Source and target features must have the same dimension")
+
+    if seed is not None:
+        torch.manual_seed(seed)
+
+    augmented = [target_feats]
+    for t in target_feats:
+        dists = torch.cdist(t.unsqueeze(0), source_feats)[0]
+        k_small = min(k, len(dists))
+        knn_idx = dists.topk(k_small, largest=False).indices
+        for idx in knn_idx:
+            alpha = torch.rand(1, device=target_feats.device)
+            mixed = alpha * t + (1.0 - alpha) * source_feats[idx]
+            augmented.append(mixed.unsqueeze(0))
+
+    return torch.vstack(augmented)
+
+
+def _knn_distance(sample: "torch.Tensor", bank: "torch.Tensor", k: int = 5) -> "torch.Tensor":
+    """Compute the average distance to the ``k`` nearest neighbours."""
+    dists = torch.cdist(sample.unsqueeze(0), bank)[0]
+    k_small = min(k, len(dists))
+    return dists.topk(k_small, largest=False).values.mean()
+
+
+def knn_anomaly_score(
+    sample: "torch.Tensor", source_bank: "torch.Tensor", target_bank: "torch.Tensor", k: int = 5
+) -> Tuple[float, float, float]:
+    """Compute kNN-based anomaly scores for ``sample``.
+
+    Parameters
+    ----------
+    sample:
+        Feature vector representing the test sample with shape ``[D]``.
+    source_bank:
+        Memory bank built from source-domain features with shape ``[N_s, D]``.
+    target_bank:
+        Memory bank built from (augmented) target-domain features with shape
+        ``[N_t, D]``.
+    k:
+        Number of neighbours used to compute the kNN distance.
+
+    Returns
+    -------
+    Tuple[float, float, float]
+        ``(score, dist_source, dist_target)`` where ``score`` is the minimum of
+        the two distances.  Higher scores indicate that the sample is more
+        anomalous.
+    """
+    _check_torch()
+
+    if sample.ndim != 1:
+        raise ValueError("Sample must be a 1-D feature vector")
+
+    d_s = _knn_distance(sample, source_bank, k)
+    d_t = _knn_distance(sample, target_bank, k)
+    score = torch.minimum(d_s, d_t)
+    return float(score), float(d_s), float(d_t)


### PR DESCRIPTION
## Summary
- add `BEATsFeatureExtractor` with temporal mean pooling and spectral preservation
- implement memory mixup augmentation and kNN anomaly scoring utilities
- provide high-level pipeline to build memory banks and score samples

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a31f3ebdfc8331ab790512accbea2e